### PR TITLE
added timeline item events

### DIFF
--- a/lib/screens/gh_issue.dart
+++ b/lib/screens/gh_issue.dart
@@ -172,6 +172,13 @@ __typename
   }
   milestoneTitle
 }
+... on DemilestonedEvent {
+  createdAt
+  actor {
+    login
+  }
+  milestoneTitle
+}
 ... on LockedEvent {
   createdAt
   actor {
@@ -190,12 +197,23 @@ __typename
   actor {
     login
   }
-  user {
+  assignee
+}
+... on UnassignedEvent {
+  createdAt
+  actor {
     login
   }
+  assignee
 }
 ... on SubscribedEvent {
   createdAt
+  actor {
+    login
+  }
+}
+... on UnsubscribedEvent {
+  createdAt 
   actor {
     login
   }
@@ -212,6 +230,18 @@ __typename
     login
   }
 }
+... on TransferredEvent {
+  createdAt
+  actor {
+    login
+  }
+  fromRepository {
+    owner {
+      login
+    }
+    name
+  }
+}
 ''';
 
     if (isPullRequest) {
@@ -225,6 +255,57 @@ __typename
         login
       }
     }
+  }
+}
+... on DeployedEvent {
+  createdAt
+  actor {
+    login
+  }
+  pullRequest {
+    headRef {
+      name
+    }
+  }
+}
+... on DeploymentEnvironmentChangedEvent {
+  createdAt
+  actor {
+    login
+  }
+  deploymentStatus {
+    deployment {
+      environment
+    }
+    description
+  }
+}
+... on HeadRefRestoredEvent {
+  createdAt
+  actor {
+    login
+  }
+  pullRequest {
+    headRef {
+      name
+    }
+  }
+}
+... on BaseRefForcePushedEvent {
+  createdAt
+  actor {
+    login
+  }
+  pullRequest {
+    baseRef {
+      name
+    }
+  }
+  beforeCommit {
+    oid
+  }
+  afterCommit {
+    oid
   }
 }
 ... on HeadRefForcePushedEvent {
@@ -251,6 +332,29 @@ __typename
   }
   requestedReviewer {
     ... on User {
+      login
+    }
+  }
+}
+... on ReviewRequestRemovedEvent {
+  createdAt
+  actor {
+    login
+  }
+  requestedReviewer {
+    ... on User {
+      login
+    }
+  }
+}
+... on ReviewDismissedEvent {
+  createdAt
+  actor {
+    login
+  }
+  dismissalMessage
+  pullRequest {
+    author {
       login
     }
   }

--- a/lib/widgets/timeline_item.dart
+++ b/lib/widgets/timeline_item.dart
@@ -134,11 +134,28 @@ class TimelineItem extends StatelessWidget {
           p: p,
         );
       case 'UnsubscribedEvent':
-        return defaultItem; // TODO:
+        return TimelineEventItem( 
+          actor: p['actor']['login'],
+          textSpan: TextSpan(text: ' unsubscribed from this issue '),
+          p: p,
+        );
       case 'ReferencedEvent':
         // TODO: isCrossRepository
         if (p['commit'] == null) {
           return Container();
+        }
+
+        if(p['isCrossRepository']) {
+          return TimelineEventItem(
+            actor: p['actor']['login'],
+            iconData: Octicons.bookmark,
+            textSpan: TextSpan(children: [
+              TextSpan(text: ' referenced this pull request from commit '),
+              TextSpan(text: p['commit']['oid'].substring(0, 8)),
+              TextSpan(text: ' from ' + p['commitRepository']['name']),
+            ]),
+            p: p,
+          );
         }
 
         return TimelineEventItem(
@@ -156,12 +173,22 @@ class TimelineItem extends StatelessWidget {
           iconData: Octicons.key,
           textSpan: TextSpan(children: [
             TextSpan(text: ' assigned this to '),
-            TextSpan(text: p['user']['login'])
+            // TextSpan(text: p['user']['login'])
+            // User field is depracated. Assignee should be used
+            TextSpan(text: p['assignee']),
           ]),
           p: p,
         );
       case 'UnassignedEvent':
-        return defaultItem; // TODO:
+        return TimelineEventItem(
+          actor: p['actor']['login'],
+          iconData: Octicons.key,
+          textSpan: TextSpan(children: [
+            TextSpan(text: ' unassigned this from '),
+            TextSpan(text: p['assignee']),
+          ]),
+          p: p,
+        );
       case 'LabeledEvent':
         return TimelineEventItem(
           actor: p['actor']['login'],
@@ -197,7 +224,16 @@ class TimelineItem extends StatelessWidget {
           p: p,
         );
       case 'DemilestonedEvent':
-        return defaultItem; // TODO:
+        return TimelineEventItem(
+          actor: p['actor']['login'],
+          iconData: Octicons.milestone,
+          textSpan: TextSpan(children: [
+            TextSpan(text: ' removed this from '),
+            TextSpan(text: p['milestoneTitle']),
+            TextSpan(text: ' milestone'),
+          ]),
+          p: p,
+        );
       case 'RenamedTitleEvent':
         return TimelineEventItem(
           actor: p['actor']['login'],
@@ -234,7 +270,14 @@ class TimelineItem extends StatelessWidget {
 
       // issue only types
       case 'TransferredEvent':
-        return defaultItem; // TODO:
+        return TimelineEventItem( 
+          actor: p['actor']['login'],
+          textSpan: TextSpan( 
+            children: [
+              TextSpan(text: ' transferred this issue from ' + p['fromRepository']['name'])
+            ],
+          ),
+        );
 
       // pull request only types
       case 'CommitCommentThread':
@@ -276,8 +319,15 @@ class TimelineItem extends StatelessWidget {
           textSpan: TextSpan(text: ' pinned this issue '),
         );
       case 'DeployedEvent':
+        return TimelineEventItem(  
+          actor: p['actor']['login'],
+          textSpan: TextSpan(text: ' deployed the pull request ' + p['pullRequest']['name']),
+        );
       case 'DeploymentEnvironmentChangedEvent':
-        return defaultItem; // TODO:
+        return TimelineEventItem(  
+          actor: p['actor']['login'],
+          textSpan: TextSpan(text: ' changed the deployment environment to ' + p['deploymentStatus']['deployment']['environment']),
+        );
       case 'HeadRefDeletedEvent':
         return TimelineEventItem(
           actor: p['actor']['login'],
@@ -290,6 +340,18 @@ class TimelineItem extends StatelessWidget {
           p: p,
         );
       case 'HeadRefRestoredEvent':
+        return TimelineEventItem(  
+          actor: p['actor']['login'],
+          textSpan: TextSpan(
+            children: [
+              TextSpan(text: ' restored the '),
+              WidgetSpan(  
+                child: PrimerBranchName(p['pullRequest']['headRef']['name'])
+              ),
+              TextSpan(text: ' branch')
+            ]
+          ),
+        );
       case 'HeadRefForcePushedEvent':
         return TimelineEventItem(
           iconData: Octicons.repo_force_push,
@@ -314,7 +376,28 @@ class TimelineItem extends StatelessWidget {
           p: p,
         );
       case 'BaseRefForcePushedEvent':
-        return defaultItem; // TODO:
+        return TimelineEventItem(
+          iconData: Octicons.repo_force_push,
+          actor: p['actor']['login'],
+          textSpan: TextSpan(
+            children: [
+              TextSpan(text: ' force-pushed the '),
+              WidgetSpan(
+                  child: PrimerBranchName(p['pullRequest']['baseRef']['name'])),
+              TextSpan(text: ' branch from '),
+              TextSpan(
+                text: (p['beforeCommit']['oid'] as String).substring(0, 7),
+                style: TextStyle(color: theme.palette.primary),
+              ),
+              TextSpan(text: ' to '),
+              TextSpan(
+                text: (p['afterCommit']['oid'] as String).substring(0, 7),
+                style: TextStyle(color: theme.palette.primary),
+              ),
+            ],
+          ),
+          p: p,
+        );
       case 'ReviewRequestedEvent':
         return TimelineEventItem(
           iconData: Octicons.eye,
@@ -326,8 +409,25 @@ class TimelineItem extends StatelessWidget {
           p: p,
         );
       case 'ReviewRequestRemovedEvent':
+        return TimelineEventItem(
+          iconData: Octicons.eye,
+          actor: p['actor']['login'],
+          textSpan: TextSpan(children: [
+            TextSpan(text: ' removed '),
+            createUserSpan(context, p['requestedReviewer']['login']),
+            TextSpan(text: ' from the review request '),
+          ]),
+          p: p,
+        );
       case 'ReviewDismissedEvent':
-        return defaultItem; // TODO:
+        return TimelineEventItem( 
+          iconData: Octicons.eye,
+          actor: p['actor']['login'],
+          textSpan: TextSpan(children: [
+            TextSpan(text: ' dismissed the pull request review requested by '),
+            createUserSpan(context, p['pullRequest']['author']['login'])
+          ]),
+        );
       default:
         return defaultItem;
     }


### PR DESCRIPTION
Fixes #3 
1. `CommitCommentThread`
2. `PullRequestReviewThread`
3. `PullRequestReviewComment`

Apart from the above three, I've implemented everything else. 
I also updated the `LockedEvent` to use `assignee` instead of the now deprecated `user`.

I'm not exactly sure how to implement these. Aren't these already built by the final widget `build`?  I could just modify the `if` statement of the final widget `build` to include the above three events. Would I be right in doing so?