### PR TITLE
fix: yellow underline

### DIFF
--- a/lib/widgets/language_bar.dart
+++ b/lib/widgets/language_bar.dart
@@ -84,6 +84,8 @@ class LanguageBar extends StatelessWidget {
                     style: TextStyle(
                       color: theme.palette.text,
                       fontSize: 18,
+                      decoration: TextDecoration.underline,
+                      decorationColor: theme.palette.background,
                     ),
                   ),
                 ]),
@@ -95,6 +97,8 @@ class LanguageBar extends StatelessWidget {
                   style: TextStyle(
                     color: theme.palette.secondaryText,
                     fontSize: 18,
+                    decoration: TextDecoration.underline,
+                    decorationColor: theme.palette.background,
                   ),
                 ),
               ),


### PR DESCRIPTION
An unwanted yellow decoration appears in the language bar pop up in Material Theme. I overwrote it with the background color of the application. Attaching a picture for reference. Let me know if you have a better way to fix this. Thanks. 

![image](https://user-images.githubusercontent.com/28999492/80096327-03db3c00-8587-11ea-88ee-0f5dc519a307.png)
