### PR TITLE
fix: transparent status bar

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:git_touch/home.dart';
 import 'package:git_touch/models/auth.dart';
 import 'package:git_touch/models/theme.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter/services.dart';
 
 class MyApp extends StatelessWidget {
   Widget _buildChild(BuildContext context) {
@@ -31,6 +32,10 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final auth = Provider.of<AuthModel>(context);
+    // To match status bar color to app bar color
+    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
+      statusBarColor: Colors.transparent,
+    ));
     return Container(key: auth.rootKey, child: _buildChild(context));
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,7 +4,6 @@ import 'package:git_touch/home.dart';
 import 'package:git_touch/models/auth.dart';
 import 'package:git_touch/models/theme.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter/services.dart';
 
 class MyApp extends StatelessWidget {
   Widget _buildChild(BuildContext context) {
@@ -32,10 +31,6 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final auth = Provider.of<AuthModel>(context);
-    // To match status bar color to app bar color
-    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
-      statusBarColor: Colors.transparent,
-    ));
     return Container(key: auth.rootKey, child: _buildChild(context));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:git_touch/models/notification.dart';
 import 'package:fluro/fluro.dart';
 import 'package:fimber/fimber.dart';
+import 'package:flutter/services.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -61,6 +62,11 @@ void main() async {
     themeModel.router.define(GithubRouter.prefix + screen.path,
         handler: Handler(handlerFunc: screen.handler));
   });
+
+  // To match status bar color to app bar color
+  SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
+    statusBarColor: Colors.transparent,
+  ));
 
   runApp(MultiProvider(
     providers: [


### PR DESCRIPTION
## Before: 

![image](https://user-images.githubusercontent.com/28999492/80523891-69c32b80-89ac-11ea-8e00-d85ec44f463b.png)

## After:

![image](https://user-images.githubusercontent.com/28999492/80523916-747dc080-89ac-11ea-8196-d08fcf583ef0.png)

Looks better right? Also makes it more consistent with the look on iOS.