### PR TITLE
refactor: tweak tab index saving

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -32,7 +32,6 @@ class _HomeState extends State<Home> {
   final GlobalKey<NavigatorState> tab3 = GlobalKey<NavigatorState>();
   final GlobalKey<NavigatorState> tab4 = GlobalKey<NavigatorState>();
   final GlobalKey<NavigatorState> tab5 = GlobalKey<NavigatorState>();
-  final CupertinoTabController _controller = CupertinoTabController();
 
   _buildScreen(int index) {
     // return GlProjectScreen(32221);
@@ -204,91 +203,48 @@ class _HomeState extends State<Home> {
       return LoginScreen();
     }
 
-    switch (auth.activeAccount.platform) {
-      case PlatformType.github:
-        theme.setActiveTab(theme.startTabGh);
-        break;
-      case PlatformType.gitlab:
-        theme.setActiveTab(theme.startTabGl);
-        break;
-      case PlatformType.bitbucket:
-        theme.setActiveTab(theme.startTabBb);
-        break;
-      case PlatformType.gitea:
-        theme.setActiveTab(theme.startTabGt);
-        break;
-    }
-
-    _controller.index = theme.active;
-
     switch (theme.theme) {
       case AppThemeType.cupertino:
         return WillPopScope(
-            onWillPop: () async {
-              return !await getNavigatorKey(_controller.index)
-                  .currentState
-                  .maybePop();
-            },
-            child: CupertinoTabScaffold(
-                controller: _controller,
-                tabBuilder: (context, index) {
-                  return CupertinoTabView(
-                      navigatorKey: getNavigatorKey(index),
-                      builder: (context) {
-                        return _buildScreen(index);
-                      });
+          onWillPop: () async {
+            return !await getNavigatorKey(auth.activeTab)
+                .currentState
+                ?.maybePop();
+          },
+          child: CupertinoTabScaffold(
+            tabBuilder: (context, index) {
+              return CupertinoTabView(
+                navigatorKey: getNavigatorKey(index),
+                builder: (context) {
+                  return _buildScreen(index);
                 },
-                tabBar: CupertinoTabBar(
-                    items: _navigationItems,
-                    currentIndex: _controller.index,
-                    onTap: (index) {
-                      if (theme.active == index) {
-                        getNavigatorKey(index)
-                            .currentState
-                            .popUntil((route) => route.isFirst);
-                      }
-                      theme.setActiveTab(index);
-                      switch (auth.activeAccount.platform) {
-                        case PlatformType.github:
-                          theme.setDefaultStartTabGh(index);
-                          break;
-                        case PlatformType.gitlab:
-                          theme.setDefaultStartTabGl(index);
-                          break;
-                        case PlatformType.bitbucket:
-                          theme.setDefaultStartTabBb(index);
-                          break;
-                        case PlatformType.gitea:
-                          theme.setDefaultStartTabGt(index);
-                          break;
-                      }
-                    })));
+              );
+            },
+            tabBar: CupertinoTabBar(
+              items: _navigationItems,
+              currentIndex: auth.activeTab,
+              onTap: (index) {
+                if (auth.activeTab == index) {
+                  getNavigatorKey(index)
+                      .currentState
+                      ?.popUntil((route) => route.isFirst);
+                } else {
+                  auth.setActiveTab(index);
+                }
+              },
+            ),
+          ),
+        );
       default:
         return Scaffold(
-          body: _buildScreen(theme.active),
+          body: _buildScreen(auth.activeTab),
           bottomNavigationBar: BottomNavigationBar(
             selectedItemColor: theme.palette.primary,
             items: _navigationItems,
-            currentIndex: theme.active,
+            currentIndex: auth.activeTab,
             type: BottomNavigationBarType.fixed,
             onTap: (int index) {
-              switch (auth.activeAccount.platform) {
-                case PlatformType.github:
-                  theme.setDefaultStartTabGh(index);
-                  break;
-                case PlatformType.gitlab:
-                  theme.setDefaultStartTabGl(index);
-                  break;
-                case PlatformType.bitbucket:
-                  theme.setDefaultStartTabBb(index);
-                  break;
-                case PlatformType.gitea:
-                  theme.setDefaultStartTabGt(index);
-                  break;
-              }
-              setState(() {
-                theme.setActiveTab(index);
-              });
+              auth.setActiveTab(index);
             },
           ),
         );

--- a/lib/models/auth.dart
+++ b/lib/models/auth.dart
@@ -325,10 +325,14 @@ class AuthModel with ChangeNotifier {
   }
 
   var rootKey = UniqueKey();
-  void setActiveAccountAndReload(int index) {
+  setActiveAccountAndReload(int index) async {
     // https://stackoverflow.com/a/50116077
     rootKey = UniqueKey();
     activeAccountIndex = index;
+    final prefs = await SharedPreferences.getInstance();
+    _activeTab = prefs.getInt(
+            StorageKeys.getDefaultStartTabKey(activeAccount.platform)) ??
+        0;
     _ghClient = null;
     _gqlClient = null;
     notifyListeners();
@@ -401,5 +405,17 @@ class AuthModel with ChangeNotifier {
     launchUrl(
       'https://github.com/login/oauth/authorize?client_id=$clientId&redirect_uri=gittouch://login&scope=$scope&state=$_oauthState',
     );
+  }
+
+  int _activeTab = 0;
+  int get activeTab => _activeTab;
+
+  Future<void> setActiveTab(int v) async {
+    _activeTab = v;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(
+        StorageKeys.getDefaultStartTabKey(activeAccount.platform), v);
+    Fimber.d('write default start tab for ${activeAccount.platform}: $v');
+    notifyListeners();
   }
 }

--- a/lib/models/theme.dart
+++ b/lib/models/theme.dart
@@ -115,59 +115,6 @@ class ThemeModel with ChangeNotifier {
   int _brightnessValue = AppBrightnessType.followSystem;
   int get brighnessValue => _brightnessValue;
 
-  Future<void> setActiveTab(int v) async {
-    _activeTab = v;
-    Fimber.d('write active tab: $v');
-    notifyListeners();
-  }
-
-  int _activeTab = 0;
-  int get active => _activeTab;
-
-  int _defaultStartTabGh = 0;
-  int get startTabGh => _defaultStartTabGh;
-
-  Future<void> setDefaultStartTabGh(int v) async {
-    _defaultStartTabGh = v;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(StorageKeys.defaultStartTabGh, v);
-    Fimber.d('write default start tab for github: $v');
-    notifyListeners();
-  }
-
-  int _defaultStartTabGl = 0;
-  int get startTabGl => _defaultStartTabGl;
-
-  Future<void> setDefaultStartTabGl(int v) async {
-    _defaultStartTabGl = v;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(StorageKeys.defaultStartTabGl, v);
-    Fimber.d('write default start tab for gitlab: $v');
-    notifyListeners();
-  }
-
-  int _defaultStartTabBb = 0;
-  int get startTabBb => _defaultStartTabBb;
-
-  Future<void> setDefaultStartTabBb(int v) async {
-    _defaultStartTabBb = v;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(StorageKeys.defaultStartTabBb, v);
-    Fimber.d('write default start tab for bitbucket: $v');
-    notifyListeners();
-  }
-
-  int _defaultStartTabGt = 0;
-  int get startTabGt => _defaultStartTabGt;
-
-  Future<void> setDefaultStartTabGt(int v) async {
-    _defaultStartTabGt = v;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(StorageKeys.defaultStartTabGt, v);
-    Fimber.d('write default start tab for gitea: $v');
-    notifyListeners();
-  }
-
   // could be null
   Brightness get brightness {
     switch (_brightnessValue) {
@@ -235,15 +182,6 @@ class ThemeModel with ChangeNotifier {
     if (AppBrightnessType.values.contains(b)) {
       _brightnessValue = b;
     }
-    final dGh = prefs.getInt(StorageKeys.defaultStartTabGh);
-    _defaultStartTabGh = dGh;
-    final dGl = prefs.getInt(StorageKeys.defaultStartTabGl);
-    _defaultStartTabGl = dGl;
-    final dBb = prefs.getInt(StorageKeys.defaultStartTabBb);
-    _defaultStartTabBb = dBb;
-    final dGt = prefs.getInt(StorageKeys.defaultStartTabGt);
-    _defaultStartTabGt = dGt;
-
     notifyListeners();
   }
 

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -38,7 +38,7 @@ import 'package:git_touch/screens/settings.dart';
 import 'package:git_touch/screens/gh_user.dart';
 import 'package:git_touch/screens/gh_users.dart';
 import 'package:git_touch/screens/gh_user_organization.dart';
-import 'package:git_touch/screens/gh_gists.dart';
+// import 'package:git_touch/screens/gh_gists.dart';
 
 class RouterScreen {
   String path;
@@ -97,7 +97,7 @@ class GithubRouter {
       case 'organizations':
         return GhUserOrganizationScreen(login);
       case 'gists':
-        return GhGistsScreen(login);
+      // return GhGistsScreen(login);
       default:
         return GhUserScreen(login);
     }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -26,10 +26,9 @@ class StorageKeys {
   static const codeThemeDark = 'code-theme-dark';
   static const iCodeFontSize = 'code-font-size';
   static const codeFontFamily = 'code-font-family';
-  static const defaultStartTabGh = 'default-start-tab-github';
-  static const defaultStartTabGl = 'default-start-tab-gitlab';
-  static const defaultStartTabBb = 'default-start-tab-bitbucket';
-  static const defaultStartTabGt = 'default-start-tab-gitea';
+
+  static getDefaultStartTabKey(String platform) =>
+      'default-start-tab-$platform';
 }
 
 class CommonStyle {


### PR DESCRIPTION
* Move `activeTab` variable to `auth` model
* Drop `CupertinoTabController` and use `auth.activeTab` as the single source of truth 
* Move `setActiveTab` method from `build` to account select handler
* Comment `GhGistsScreen` temporarily since it is not submitted yet