### PR TITLE
fix: api change user to accountID

### DIFF
--- a/lib/models/account.dart
+++ b/lib/models/account.dart
@@ -12,6 +12,7 @@ class Account {
   String avatarUrl;
   int gitlabId; // For GitLab
   String appPassword; // For Bitbucket
+  String accountId; // For Bitbucket
 
   // equals(Account a) {
   //   final uri = Uri.parse(domain);
@@ -33,6 +34,7 @@ class Account {
     @required this.avatarUrl,
     this.gitlabId,
     this.appPassword,
+    this.accountId,
   });
 
   factory Account.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/account.g.dart
+++ b/lib/models/account.g.dart
@@ -15,6 +15,7 @@ Account _$AccountFromJson(Map<String, dynamic> json) {
     avatarUrl: json['avatarUrl'] as String,
     gitlabId: json['gitlabId'] as int,
     appPassword: json['appPassword'] as String,
+    accountId: json['accountId'] as String,
   );
 }
 
@@ -34,5 +35,6 @@ Map<String, dynamic> _$AccountToJson(Account instance) {
   writeNotNull('avatarUrl', instance.avatarUrl);
   writeNotNull('gitlabId', instance.gitlabId);
   writeNotNull('appPassword', instance.appPassword);
+  writeNotNull('accountId', instance.accountId);
   return val;
 }

--- a/lib/models/auth.dart
+++ b/lib/models/auth.dart
@@ -261,6 +261,7 @@ class AuthModel with ChangeNotifier {
         login: username,
         avatarUrl: user.avatarUrl,
         appPassword: appPassword,
+        accountId: user.accountId,
       ));
     } finally {
       loading = false;

--- a/lib/models/bitbucket.dart
+++ b/lib/models/bitbucket.dart
@@ -30,6 +30,7 @@ class BbUser extends BbRepoOwner {
   String username;
   bool isStaff;
   DateTime createdOn;
+  String accountId;
   BbUser();
   factory BbUser.fromJson(Map<String, dynamic> json) => _$BbUserFromJson(json);
 }

--- a/lib/models/bitbucket.g.dart
+++ b/lib/models/bitbucket.g.dart
@@ -50,7 +50,8 @@ BbUser _$BbUserFromJson(Map<String, dynamic> json) {
     ..isStaff = json['is_staff'] as bool
     ..createdOn = json['created_on'] == null
         ? null
-        : DateTime.parse(json['created_on'] as String);
+        : DateTime.parse(json['created_on'] as String)
+    ..accountId = json['account_id'] as String;
 }
 
 Map<String, dynamic> _$BbUserToJson(BbUser instance) => <String, dynamic>{
@@ -61,6 +62,7 @@ Map<String, dynamic> _$BbUserToJson(BbUser instance) => <String, dynamic>{
       'username': instance.username,
       'is_staff': instance.isStaff,
       'created_on': instance.createdOn?.toIso8601String(),
+      'account_id': instance.accountId,
     };
 
 BbRepo _$BbRepoFromJson(Map<String, dynamic> json) {

--- a/lib/screens/bb_user.dart
+++ b/lib/screens/bb_user.dart
@@ -19,12 +19,13 @@ class BbUserScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final auth = Provider.of<AuthModel>(context);
+    final _accountId = auth.activeAccount.accountId;
     final _login = login ?? auth.activeAccount.login;
     return RefreshStatefulScaffold<Tuple2<BbUser, Iterable<BbRepo>>>(
       title: Text(isViewer ? 'Me' : isTeam ? 'Team' : 'User'),
       fetchData: () async {
         final res = await Future.wait([
-          auth.fetchBbJson('/${isTeam ? 'teams' : 'users'}/$_login'),
+          auth.fetchBbJson('/${isTeam ? 'teams' : 'users'}/$_accountId'),
           auth.fetchBbWithPage('/repositories/$_login'),
         ]);
         return Tuple2(


### PR DESCRIPTION
Fixes #79 
- Added `accountId` field in `account.dart`.
- change request to fetch using `accountId` instead of `username` as per [this](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#removal-of-usernames-from-user-referencing-apis).

@pd4d10 Works for me now. Can you check at your end?