### PR TITLE
fix: commit comment event render error

### DIFF
--- a/lib/models/github.dart
+++ b/lib/models/github.dart
@@ -106,6 +106,8 @@ class GithubEventIssue {
 class GithubEventComment {
   String body;
   GithubEventUser user;
+  String commitId;
+  String htmlUrl;
 
   GithubEventComment();
 

--- a/lib/models/github.g.dart
+++ b/lib/models/github.g.dart
@@ -174,13 +174,17 @@ GithubEventComment _$GithubEventCommentFromJson(Map<String, dynamic> json) {
     ..body = json['body'] as String
     ..user = json['user'] == null
         ? null
-        : GithubEventUser.fromJson(json['user'] as Map<String, dynamic>);
+        : GithubEventUser.fromJson(json['user'] as Map<String, dynamic>)
+    ..commitId = json['commit_id'] as String
+    ..htmlUrl = json['html_url'] as String;
 }
 
 Map<String, dynamic> _$GithubEventCommentToJson(GithubEventComment instance) =>
     <String, dynamic>{
       'body': instance.body,
       'user': instance.user,
+      'commit_id': instance.commitId,
+      'html_url': instance.htmlUrl,
     };
 
 GithubEventCommit _$GithubEventCommitFromJson(Map<String, dynamic> json) {

--- a/lib/widgets/event_item.dart
+++ b/lib/widgets/event_item.dart
@@ -164,6 +164,46 @@ class EventItem extends StatelessWidget {
     );
   }
 
+  // Todo: Add a screen for the url
+  Widget _buildCommitCommentCard(BuildContext context) {
+    final theme = Provider.of<ThemeModel>(context);
+    return Link(
+      url: e.payload.comment.htmlUrl,
+      child: Container(
+        padding: EdgeInsets.all(12),
+        decoration: BoxDecoration(
+            color: theme.palette.grayBackground,
+            borderRadius: BorderRadius.all(Radius.circular(4))),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: <Widget>[
+                Text(
+                  e.payload.comment.commitId.substring(0, 7),
+                  style: TextStyle(
+                    color: theme.palette.primary,
+                    fontSize: 15,
+                    fontFamily: CommonStyle.monospace,
+                  ),
+                ),
+                SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    e.payload.comment.body,
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 1,
+                    style: TextStyle(color: theme.palette.text, fontSize: 15),
+                  ),
+                )
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildIssueCard(
       BuildContext context, GithubEventIssue issue, String body,
       {isPullRequest = false}) {
@@ -293,11 +333,11 @@ class EventItem extends StatelessWidget {
         return _buildItem(
           context: context,
           spans: [
-            TextSpan(text: ' ${e.payload.action} a comment on the commit at '),
+            TextSpan(text: ' commented on a commit '),
+            TextSpan(text: ' at '),
             _buildRepo(context),
-            TextSpan(text: ' ${e.payload.comment.body} '),
           ],
-          card: _buildCommitsCard(context),
+          card: _buildCommitCommentCard(context),
         );
       case 'ContentReferenceEvent':
         return _buildItem(context: context, spans: [


### PR DESCRIPTION
- Blank news screen for those with a `CommitComment` event in their feed.
- `CommitComment` event rendered my news screen blank today. Took some time to figure that out.
- My bad, I should've paid more attention to the json response clearly to have avoided the use of `buildCommitsCard` for this event.

This was the error:

![image](https://user-images.githubusercontent.com/28999492/82120090-487e7f80-97a1-11ea-9b9e-8178643cdbfd.png)

After fixing: 

![image](https://user-images.githubusercontent.com/28999492/82120096-5207e780-97a1-11ea-9968-a31f72833a3b.png)
