### PR TITLE
fix: use container to fix expansion of tab

### DIFF
--- a/lib/scaffolds/tab.dart
+++ b/lib/scaffolds/tab.dart
@@ -34,9 +34,11 @@ class TabScaffold extends StatelessWidget {
             onValueChanged: onTabSwitch,
             children: tabs.asMap().map((key, text) => MapEntry(
                 key,
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
-                  child: Text(text),
+                Container(
+                  width: 100,
+                  child: Center(
+                    child: Text(text),
+                  ),
                 ))),
           ),
         );

--- a/lib/scaffolds/tab.dart
+++ b/lib/scaffolds/tab.dart
@@ -29,17 +29,21 @@ class TabScaffold extends StatelessWidget {
       case AppThemeType.cupertino:
         return DefaultTextStyle(
           style: DefaultTextStyle.of(context).style.copyWith(fontSize: 14),
-          child: CupertinoSlidingSegmentedControl(
-            groupValue: activeTab,
-            onValueChanged: onTabSwitch,
-            children: tabs.asMap().map((key, text) => MapEntry(
-                key,
-                Container(
-                  width: 100,
-                  child: Center(
-                    child: Text(text),
-                  ),
-                ))),
+          child: Row(
+            children: [
+              Expanded(
+                child: CupertinoSlidingSegmentedControl(
+                  groupValue: activeTab,
+                  onValueChanged: onTabSwitch,
+                  children: tabs.asMap().map((key, text) => MapEntry(
+                      key,
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        child: Text(text),
+                      ))),
+                ),
+              ),
+            ],
           ),
         );
       default:


### PR DESCRIPTION
Fixes #95 

I initially made the suggestion to change the padding to 12 from 10, but that didn't work when I tried it on the iPad. Changing to a container with a fixed width did the trick.