### PR TITLE
UserItem: fix assertion failure

### DIFF
--- a/lib/widgets/user_item.dart
+++ b/lib/widgets/user_item.dart
@@ -81,6 +81,7 @@ class UserItem extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
                   Row(
+                    textBaseline: TextBaseline.alphabetic,
                     crossAxisAlignment: CrossAxisAlignment.baseline,
                     children: <Widget>[
                       if (name != null && name.isNotEmpty) ...[


### PR DESCRIPTION
With recent versions of Flutter:

    ======== Exception caught by widgets library =======================================================
    textBaseline is required if you specify the crossAxisAlignment with CrossAxisAlignment.baseline
    'package:flutter/src/widgets/basic.dart':
    Failed assertion: line 4134 pos 15: 'crossAxisAlignment != CrossAxisAlignment.baseline || textBaseline != null'
    The relevant error-causing widget was:
      UserItem file:///home/jpnurmi/Projects/flutter/git_touch/lib/screens/gh_trending.dart:51:32
    ====================================================================================================