### PR TITLE
Proper spacing in branch creation/deletion events

### DIFF
--- a/lib/widgets/event_item.dart
+++ b/lib/widgets/event_item.dart
@@ -352,7 +352,7 @@ class EventItem extends StatelessWidget {
             TextSpan(text: ' created a ${e.payload.refType}'),
             TextSpan(
                 text:
-                    '${e.payload.ref == null ? '' : ' ' + e.payload.ref + 'at'} '),
+                    '${e.payload.ref == null ? '' : ' ' + e.payload.ref + ' at'} '),
             _buildRepo(context),
           ],
         );
@@ -363,7 +363,7 @@ class EventItem extends StatelessWidget {
             TextSpan(text: ' deleted the ${e.payload.refType}'),
             TextSpan(
                 text:
-                    '${e.payload.ref == null ? '' : ' ' + e.payload.ref + 'at'} '),
+                    '${e.payload.ref == null ? '' : ' ' + e.payload.ref + ' at'} '),
             _buildRepo(context),
           ],
         );


### PR DESCRIPTION
Branch name and `at` in events don't have any space in between. This PR tries to fix that.

Edit: Tested with GitHub account.