### PR TITLE
WIP: markdown user profile links

### DIFF
--- a/lib/widgets/markdown_view.dart
+++ b/lib/widgets/markdown_view.dart
@@ -7,6 +7,10 @@ import 'package:git_touch/widgets/html_view.dart';
 import 'package:provider/provider.dart';
 import 'package:uri/uri.dart';
 import 'package:path/path.dart' as path;
+import 'package:markdown/markdown.dart' as md;
+import 'package:charcode/charcode.dart';
+
+import 'link.dart';
 
 class MarkdownViewData {
   final Future<String> future;
@@ -109,6 +113,18 @@ class MarkdownFlutterView extends StatelessWidget {
     return Container(
       padding: padding,
       child: MarkdownBody(
+        builders: {
+          "userProfileLink": UserProfileLinkElementBuilder(),
+        },
+        extensionSet: md.ExtensionSet(
+          md.ExtensionSet.gitHubFlavored.blockSyntaxes,
+          [
+            UserProfileLink(),
+            md.EmojiSyntax(),
+            md.LinkSyntax(),
+            ...md.ExtensionSet.gitHubFlavored.inlineSyntaxes
+          ],
+        ),
         data: text,
         selectable: true,
         imageBuilder: (uri, title, alt) {
@@ -210,5 +226,27 @@ class MarkdownFlutterView extends StatelessWidget {
         // syntaxHighlighter: , // TODO:
       ),
     );
+  }
+}
+
+class UserProfileLink extends md.InlineSyntax {
+  UserProfileLink() : super(r'[^\s]+ ', startCharacter: $at);
+
+  @override
+  bool onMatch(md.InlineParser parser, Match match) {
+    var alias = match[0].substring(1, match[0].length).trim();
+    parser.addNode(md.Element.text("userProfileLink", alias));
+    return true;
+  }
+}
+
+class UserProfileLinkElementBuilder extends MarkdownElementBuilder {
+  @override
+  Widget visitElementAfter(md.Element element, TextStyle prefferedStyle) {
+    return Link(
+        url: '/github/${element.textContent}',
+        child: Text(
+          '@' + element.textContent,
+        ));
   }
 }

--- a/lib/widgets/markdown_view.dart
+++ b/lib/widgets/markdown_view.dart
@@ -230,12 +230,15 @@ class MarkdownFlutterView extends StatelessWidget {
 }
 
 class UserProfileLink extends md.InlineSyntax {
-  UserProfileLink() : super(r'[^\s]+ ', startCharacter: $at);
+  // github username regex format
+  UserProfileLink()
+      : super(r'\B@([a-z0-9](?:-?[a-z0-9]){0,38})', startCharacter: $at);
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {
-    var alias = match[0].substring(1, match[0].length).trim();
-    parser.addNode(md.Element.text("userProfileLink", alias));
+    var login = match[0].substring(1, match[0].length).trim();
+    md.Node el = md.Element.text("userProfileLink", login);
+    parser.addNode(el);
     return true;
   }
 }
@@ -245,8 +248,6 @@ class UserProfileLinkElementBuilder extends MarkdownElementBuilder {
   Widget visitElementAfter(md.Element element, TextStyle prefferedStyle) {
     return Link(
         url: '/github/${element.textContent}',
-        child: Text(
-          '@' + element.textContent,
-        ));
+        child: Text('@' + element.textContent));
   }
 }


### PR DESCRIPTION
Trying to resolve #87 
- Unable to figure out how to prevent line break 
- Also since `visitElementAfter` does not have the `BuildContext context` parameter, I cannot access `ThemeModel` (to style the link text). [This](https://developer.school/custom-markdown-inlinesyntax-with-flutter/) was the link I referred for creating this PR.
- I'll also need to access `AuthModel` to get the active platform so that I can pass that in the url.

@pd4d10 I'd like your help on this. 

This is how it looks:
![image](https://user-images.githubusercontent.com/28999492/105056642-72a7e000-5a9a-11eb-8dae-2f7cdf0e5340.png)


