### PR TITLE
fix(github): allow multiple accounts

### DIFF
--- a/lib/models/auth.dart
+++ b/lib/models/auth.dart
@@ -728,13 +728,13 @@ class AuthModel with ChangeNotifier {
   }
 
   String _oauthState;
-  void redirectToGithubOauth([publicOnly = false]) {
+  void redirectToGithubOauth(String login, [publicOnly = false]) {
     _oauthState = nanoid();
     final repoScope = publicOnly ? 'public_repo' : 'repo';
     final scope = Uri.encodeComponent(
         ['user', repoScope, 'read:org', 'notifications'].join(','));
     launchUrl(
-      'https://github.com/login/oauth/authorize?client_id=$clientId&redirect_uri=gittouch://login&scope=$scope&state=$_oauthState',
+      'https://github.com/login/oauth/authorize?client_id=$clientId&redirect_uri=gittouch://login&scope=$scope&state=$_oauthState&login=$login',
     );
   }
 

--- a/lib/screens/login.dart
+++ b/lib/screens/login.dart
@@ -111,17 +111,16 @@ class _LoginScreenState extends State<LoginScreen> {
     );
   }
 
-  Widget _buildPopup(
-    BuildContext context, {
-    List<Widget> notes,
-    bool showDomain = false,
-  }) {
+  Widget _buildPopup(BuildContext context,
+      {List<Widget> notes,
+      bool showDomain = false,
+      String placeholder = 'Access token'}) {
     return Column(
       children: <Widget>[
         if (showDomain)
           MyTextField(controller: _domainController, placeholder: 'Domain'),
         SizedBox(height: 8),
-        MyTextField(placeholder: 'Access token', controller: _tokenController),
+        MyTextField(placeholder: placeholder, controller: _tokenController),
         SizedBox(height: 8),
         if (notes != null) ...notes,
       ],
@@ -131,6 +130,14 @@ class _LoginScreenState extends State<LoginScreen> {
   void showError(err) {
     context.read<ThemeModel>().showConfirm(context,
         Text(AppLocalizations.of(context).somethingBadHappens + '$err'));
+  }
+
+  // TODO: handle email
+  bool _checkAccountExists(BuildContext context, String domain, String login) {
+    final auth = context.read<AuthModel>();
+    final accountExists = auth.accounts
+        .where((account) => account.domain == domain && account.login == login);
+    return accountExists.isNotEmpty;
   }
 
   @override
@@ -152,14 +159,50 @@ class _LoginScreenState extends State<LoginScreen> {
                       theme.showActions(context, [
                         ActionItem(
                           text: 'via OAuth',
-                          onTap: (_) {
-                            auth.redirectToGithubOauth();
+                          onTap: (_) async {
+                            await theme.showConfirm(
+                              context,
+                              _buildPopup(
+                                context,
+                                placeholder: 'Username or email',
+                              ),
+                            );
+
+                            bool accountExists = _checkAccountExists(context,
+                                'https://github.com', _tokenController.text);
+
+                            if (accountExists) {
+                              await theme.showWarning(
+                                  context, "Account already exists");
+                            } else {
+                              auth.redirectToGithubOauth(_tokenController.text);
+                            }
+
+                            _tokenController.clear();
                           },
                         ),
                         ActionItem(
                           text: 'via OAuth (Public repos only)',
-                          onTap: (_) {
-                            auth.redirectToGithubOauth(true);
+                          onTap: (_) async {
+                            await theme.showConfirm(
+                                context,
+                                _buildPopup(
+                                  context,
+                                  placeholder: 'Username or email',
+                                ));
+
+                            bool accountExists = _checkAccountExists(context,
+                                'https://github.com', _tokenController.text);
+
+                            if (accountExists) {
+                              await theme.showWarning(
+                                  context, "Account already exists");
+                            } else {
+                              auth.redirectToGithubOauth(
+                                  _tokenController.text, true);
+                            }
+
+                            _tokenController.clear();
                           },
                         ),
                         ActionItem(


### PR DESCRIPTION
Fixes #168 

- The authorization url has a `login` prop which I used. This will allow logging in to multiple accounts.
- Regarding preventing creation of duplicate accounts, I added a method but if the user enters an email instead of the username, it won't work. (Not sure if this is the best way to do it. @pd4d10 please suggest if there's a better way)