### PR TITLE
feat: skip login screen when logged in

### DIFF
--- a/lib/models/auth.dart
+++ b/lib/models/auth.dart
@@ -632,9 +632,11 @@ class AuthModel with ChangeNotifier {
           .map((item) => Account.fromJson(item))
           .toList();
       activeAccountIndex = prefs.getInt(StorageKeys.defaultAccount);
-      _activeTab = prefs.getInt(
-              StorageKeys.getDefaultStartTabKey(activeAccount.platform)) ??
-          0;
+
+      if (activeAccount != null)
+        _activeTab = prefs.getInt(
+                StorageKeys.getDefaultStartTabKey(activeAccount.platform)) ??
+            0;
     } catch (err) {
       Fimber.e('prefs getAccount failed', ex: err);
       _accounts = [];

--- a/lib/models/auth.dart
+++ b/lib/models/auth.dart
@@ -650,7 +650,6 @@ class AuthModel with ChangeNotifier {
   }
 
   Future<void> setDefaultAccount(int v) async {
-    activeAccountIndex = v;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(StorageKeys.defaultAccount, v);
     Fimber.d('write default account: $v');

--- a/lib/models/auth.dart
+++ b/lib/models/auth.dart
@@ -631,6 +631,10 @@ class AuthModel with ChangeNotifier {
       _accounts = (json.decode(str ?? '[]') as List)
           .map((item) => Account.fromJson(item))
           .toList();
+      activeAccountIndex = prefs.getInt(StorageKeys.defaultAccount);
+      _activeTab = prefs.getInt(
+              StorageKeys.getDefaultStartTabKey(activeAccount.platform)) ??
+          0;
     } catch (err) {
       Fimber.e('prefs getAccount failed', ex: err);
       _accounts = [];
@@ -645,11 +649,20 @@ class AuthModel with ChangeNotifier {
     super.dispose();
   }
 
+  Future<void> setDefaultAccount(int v) async {
+    activeAccountIndex = v;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(StorageKeys.defaultAccount, v);
+    Fimber.d('write default account: $v');
+    notifyListeners();
+  }
+
   var rootKey = UniqueKey();
   setActiveAccountAndReload(int index) async {
     // https://stackoverflow.com/a/50116077
     rootKey = UniqueKey();
     activeAccountIndex = index;
+    setDefaultAccount(activeAccountIndex);
     final prefs = await SharedPreferences.getInstance();
     _activeTab = prefs.getInt(
             StorageKeys.getDefaultStartTabKey(activeAccount.platform)) ??

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -27,6 +27,7 @@ class StorageKeys {
   static const iCodeFontSize = 'code-font-size';
   static const codeFontFamily = 'code-font-family';
   static const markdown = 'markdown';
+  static const defaultAccount = 'default-account';
 
   static getDefaultStartTabKey(String platform) =>
       'default-start-tab-$platform';


### PR DESCRIPTION
- Closes #84 
- active tab was not set in `init()`. Fixed it. 